### PR TITLE
Implement expression simplifier and add missing trigonometric functions 

### DIFF
--- a/Sources/CalculoKit/Derivation/Deriver.swift
+++ b/Sources/CalculoKit/Derivation/Deriver.swift
@@ -41,6 +41,18 @@ public struct Deriver {
 
         case .tan(let inner):
             return (1 + .tan(inner) * .tan(inner)) * evaluate(inner, withRespectTo: variable)
+
+        case .asin(let inner):
+            let innerPrime = evaluate(inner, withRespectTo: variable)
+            return innerPrime / ((1 - inner * inner) ** 0.5)
+
+        case .acos(let inner):
+            let innerPrime = evaluate(inner, withRespectTo: variable)
+            return .constant(-1) * innerPrime / ((1 - inner * inner) ** 0.5)
+
+        case .atan(let inner):
+            let innerPrime = evaluate(inner, withRespectTo: variable)
+            return innerPrime / (1 + inner * inner)
         case .ln(let inner):
             return evaluate(inner, withRespectTo: variable) / inner
         case .exp(let inner):

--- a/Sources/CalculoKit/Evaluator/Evaluator.swift
+++ b/Sources/CalculoKit/Evaluator/Evaluator.swift
@@ -39,6 +39,15 @@ public struct Evaluator {
             case .tan(let inner):
                 guard let v = evaluate(inner, at: value, variable: variable) else { return nil }
                 return tan(v)
+            case .asin(let inner):
+                guard let v = evaluate(inner, at: value, variable: variable), v >= -1, v <= 1 else { return nil }
+                return asin(v)
+            case .acos(let inner):
+                guard let v = evaluate(inner, at: value, variable: variable), v >= -1, v <= 1 else { return nil }
+                return acos(v)
+            case .atan(let inner):
+                guard let v = evaluate(inner, at: value, variable: variable) else { return nil }
+                return atan(v)
             case .ln(let inner):
                 guard let v = evaluate(inner, at: value, variable: variable), v > 0 else { return nil }
                 return log(v)

--- a/Sources/CalculoKit/LimitEvaluator/LimitEvaluator.swift
+++ b/Sources/CalculoKit/LimitEvaluator/LimitEvaluator.swift
@@ -78,6 +78,24 @@ public struct LimitEvaluator {
             }
             return tan(v)
 
+        case .asin(let inner):
+            guard let v = evaluate(inner, approaching: point, variable: variable), v >= -1, v <= 1 else {
+                return nil
+            }
+            return asin(v)
+
+        case .acos(let inner):
+            guard let v = evaluate(inner, approaching: point, variable: variable), v >= -1, v <= 1 else {
+                return nil
+            }
+            return acos(v)
+
+        case .atan(let inner):
+            guard let v = evaluate(inner, approaching: point, variable: variable) else {
+                return nil
+            }
+            return atan(v)
+
         case .ln(let inner):
             guard let v = evaluate(inner, approaching: point, variable: variable), v > 0 else {
                 return nil

--- a/Sources/CalculoKit/MathExpr/MathExpr+Description.swift
+++ b/Sources/CalculoKit/MathExpr/MathExpr+Description.swift
@@ -31,6 +31,15 @@ extension MathExpr: CustomStringConvertible {
         case .tan(let expr):
             return "tan(\(expr))"
 
+        case .asin(let expr):
+            return "asin(\(expr))"
+
+        case .acos(let expr):
+            return "acos(\(expr))"
+
+        case .atan(let expr):
+            return "atan(\(expr))"
+
         case .ln(let expr):
             return "ln(\(expr))"
 

--- a/Sources/CalculoKit/MathExpr/MathExpr+Operators.swift
+++ b/Sources/CalculoKit/MathExpr/MathExpr+Operators.swift
@@ -7,40 +7,21 @@ precedencegroup ExponentiationPrecedence {
 infix operator ** : ExponentiationPrecedence
 
 public func + (lhs: MathExpr, rhs: MathExpr) -> MathExpr {
-    // Identity rule: x + 0 = x
-    if case .constant(let v) = lhs, v == 0 { return rhs }
-    if case .constant(let v) = rhs, v == 0 { return lhs }
-    return .addition(lhs, rhs)
+    .addition(lhs, rhs).simplified()
 }
 
 public func ** (lhs: MathExpr, rhs: MathExpr) -> MathExpr {
-    if case .constant(let v) = rhs {
-        if v == 1 { return lhs }
-        if v == 0 { return 1 }
-    }
-    return .pow(lhs, rhs)
+    .pow(lhs, rhs).simplified()
 }
 
 public func - (lhs: MathExpr, rhs: MathExpr) -> MathExpr {
-    return .subtraction(lhs, rhs)
+    .subtraction(lhs, rhs).simplified()
 }
 
 public func * (lhs: MathExpr, rhs: MathExpr) -> MathExpr {
-    // Zero rule
-    if case .constant(let v) = lhs, v == 0 { return 0 }
-    if case .constant(let v) = rhs, v == 0 { return 0 }
-
-    // Identity rule
-    if case .constant(let v) = lhs, v == 1 { return rhs }
-    if case .constant(let v) = rhs, v == 1 { return lhs }
-
-    return .multiplication(lhs, rhs)
+    .multiplication(lhs, rhs).simplified()
 }
 
 public func / (lhs: MathExpr, rhs: MathExpr) -> MathExpr {
-    // Division by 1
-    if lhs == rhs { return 1 }
-    if case .constant(let v) = rhs, v == 1 { return lhs }
-    if case .constant(let v) = lhs, v == 0 { return 0 }
-    return .division(lhs, rhs)
+    .division(lhs, rhs).simplified()
 }

--- a/Sources/CalculoKit/MathExpr/MathExpr+Simplify.swift
+++ b/Sources/CalculoKit/MathExpr/MathExpr+Simplify.swift
@@ -1,0 +1,141 @@
+// Simplification utilities for MathExpr
+// Implements recursive simplification rules like x + 0 -> x, x * 1 -> x
+import Foundation
+
+extension MathExpr {
+    /// Returns a simplified version of the expression by applying basic
+    /// algebraic rules recursively.
+    public func simplified() -> MathExpr {
+        switch self {
+        case .constant, .variable:
+            return self
+
+        case .addition(let lhs, let rhs):
+            let l = lhs.simplified()
+            let r = rhs.simplified()
+
+            if case .constant(let lv) = l, case .constant(let rv) = r {
+                return .constant(lv + rv)
+            }
+            if case .constant(let v) = l, v == 0 { return r }
+            if case .constant(let v) = r, v == 0 { return l }
+            return .addition(l, r)
+
+        case .subtraction(let lhs, let rhs):
+            let l = lhs.simplified()
+            let r = rhs.simplified()
+
+            if case .constant(let lv) = l, case .constant(let rv) = r {
+                return .constant(lv - rv)
+            }
+            if case .constant(let v) = r, v == 0 { return l }
+            return .subtraction(l, r)
+
+        case .multiplication(let lhs, let rhs):
+            let l = lhs.simplified()
+            let r = rhs.simplified()
+
+            if case .constant(let lv) = l, case .constant(let rv) = r {
+                return .constant(lv * rv)
+            }
+            if case .constant(let v) = l, v == 0 { return .constant(0) }
+            if case .constant(let v) = r, v == 0 { return .constant(0) }
+            if case .constant(let v) = l, v == 1 { return r }
+            if case .constant(let v) = r, v == 1 { return l }
+            return .multiplication(l, r)
+
+        case .division(let lhs, let rhs):
+            let l = lhs.simplified()
+            let r = rhs.simplified()
+
+            if case .constant(let lv) = l, case .constant(let rv) = r, rv != 0 {
+                return .constant(lv / rv)
+            }
+            if case .constant(let v) = l, v == 0 { return .constant(0) }
+            if l == r { return .constant(1) }
+            if case .constant(let v) = r, v == 1 { return l }
+            return .division(l, r)
+
+        case .pow(let base, let exp):
+            let b = base.simplified()
+            let e = exp.simplified()
+
+            if case .constant(let bv) = b, case .constant(let ev) = e {
+                return .constant(Foundation.pow(bv, ev))
+            }
+            if case .constant(let ev) = e {
+                if ev == 1 { return b }
+                if ev == 0 { return .constant(1) }
+            }
+            if case .constant(let bv) = b {
+                if bv == 1 { return .constant(1) }
+                if bv == 0 { return .constant(0) }
+            }
+            return .pow(b, e)
+
+        case .ln(let inner):
+            let simplifiedInner = inner.simplified()
+            if case .constant(let v) = simplifiedInner, v > 0 {
+                return .constant(Foundation.log(v))
+            }
+            return .ln(simplifiedInner)
+
+        case .log(let inner, let base):
+            let simplifiedInner = inner.simplified()
+            if case .constant(let v) = simplifiedInner, v > 0 {
+                return .constant(Foundation.log(v) / Foundation.log(base))
+            }
+            return .log(simplifiedInner, base: base)
+
+        case .exp(let inner):
+            let simplifiedInner = inner.simplified()
+            if case .constant(let v) = simplifiedInner {
+                return .constant(Foundation.exp(v))
+            }
+            return .exp(simplifiedInner)
+
+        case .sin(let inner):
+            let simplifiedInner = inner.simplified()
+            if case .constant(let v) = simplifiedInner {
+                return .constant(Foundation.sin(v))
+            }
+            return .sin(simplifiedInner)
+
+        case .cos(let inner):
+            let simplifiedInner = inner.simplified()
+            if case .constant(let v) = simplifiedInner {
+                return .constant(Foundation.cos(v))
+            }
+            return .cos(simplifiedInner)
+
+        case .tan(let inner):
+            let simplifiedInner = inner.simplified()
+            if case .constant(let v) = simplifiedInner {
+                return .constant(Foundation.tan(v))
+            }
+            return .tan(simplifiedInner)
+
+        case .asin(let inner):
+            let simplifiedInner = inner.simplified()
+            if case .constant(let v) = simplifiedInner, v >= -1, v <= 1 {
+                return .constant(Foundation.asin(v))
+            }
+            return .asin(simplifiedInner)
+
+        case .acos(let inner):
+            let simplifiedInner = inner.simplified()
+            if case .constant(let v) = simplifiedInner, v >= -1, v <= 1 {
+                return .constant(Foundation.acos(v))
+            }
+            return .acos(simplifiedInner)
+
+        case .atan(let inner):
+            let simplifiedInner = inner.simplified()
+            if case .constant(let v) = simplifiedInner {
+                return .constant(Foundation.atan(v))
+            }
+            return .atan(simplifiedInner)
+        }
+    }
+}
+

--- a/Sources/CalculoKit/MathExpr/MathExpr.swift
+++ b/Sources/CalculoKit/MathExpr/MathExpr.swift
@@ -14,6 +14,9 @@ public indirect enum MathExpr: Sendable {
     case sin(MathExpr)
     case cos(MathExpr)
     case tan(MathExpr)
+    case asin(MathExpr)
+    case acos(MathExpr)
+    case atan(MathExpr)
 }
 
 // MARK: - Equatable
@@ -36,7 +39,10 @@ extension MathExpr: Equatable {
         // ── Unary trig ─────────────────────────────────────────────
         case (.sin(let a), .sin(let b)),
              (.cos(let a), .cos(let b)),
-             (.tan(let a), .tan(let b)):
+             (.tan(let a), .tan(let b)),
+             (.asin(let a), .asin(let b)),
+             (.acos(let a), .acos(let b)),
+             (.atan(let a), .atan(let b)):
             return a == b
 
         // ── Log / Exp ──────────────────────────────────────────────

--- a/Tests/CalculoKitTests/EvaluatorTests.swift
+++ b/Tests/CalculoKitTests/EvaluatorTests.swift
@@ -25,6 +25,12 @@ struct EvaluatorTests {
         #expect(abs((res ?? 0) - 1) < 1e-6)
     }
 
+    @Test func testInverseTrig() {
+        let expr = MathExpr.asin(.constant(1))
+        let res = Evaluator().evaluate(expr, at: 0)
+        #expect(abs((res ?? 0) - Double.pi/2) < 1e-6)
+    }
+
     @Test func testDivisionByZero() {
         let expr = 1 / .x
         #expect(Evaluator().evaluate(expr, at: 0) == nil)

--- a/Tests/CalculoKitTests/SimplifyTests.swift
+++ b/Tests/CalculoKitTests/SimplifyTests.swift
@@ -1,0 +1,24 @@
+import Testing
+@testable import CalculoKit
+
+struct SimplifyTests {
+    @Test func testAdditionOfConstants() {
+        let expr: MathExpr = 2 + 3
+        #expect(expr.simplified() == 5)
+    }
+
+    @Test func testNestedSimplification() {
+        let expr: MathExpr = (.x + 0) * 1
+        #expect(expr.simplified() == .x)
+    }
+
+    @Test func testPowerSimplification() {
+        let expr: MathExpr = (.x ** 1) + (.x ** 0)
+        #expect(expr.simplified() == .x + 1)
+    }
+
+    @Test func testInverseTrigSimplification() {
+        let expr: MathExpr = .asin(0)
+        #expect(expr.simplified() == 0)
+    }
+}

--- a/Tests/CalculoKitTests/TrigAndLogDerivativeTests.swift
+++ b/Tests/CalculoKitTests/TrigAndLogDerivativeTests.swift
@@ -20,6 +20,24 @@ struct TrigAndLogDerivativeTests {
         #expect(dx == expected)
     }
 
+    @Test func testDerivativeOfAsinX() {
+        let dx = Deriver().evaluate(.asin(.x), withRespectTo: .x)
+        let expected = 1 / ((1 - .x * .x) ** 0.5)
+        #expect(dx == expected)
+    }
+
+    @Test func testDerivativeOfAcosX() {
+        let dx = Deriver().evaluate(.acos(.x), withRespectTo: .x)
+        let expected = .constant(-1) / ((1 - .x * .x) ** 0.5)
+        #expect(dx == expected)
+    }
+
+    @Test func testDerivativeOfAtanX() {
+        let dx = Deriver().evaluate(.atan(.x), withRespectTo: .x)
+        let expected = 1 / (1 + .x * .x)
+        #expect(dx == expected)
+    }
+
     @Test func testDerivativeOfLnX() {
         let dx = Deriver().evaluate(.ln(.x), withRespectTo: .x)
         #expect(dx == 1 / .x)

--- a/roadmap.md
+++ b/roadmap.md
@@ -6,17 +6,17 @@ This document tracks the progress of core features in the symbolic math library.
 
 ## ✅ Feature Roadmap
 
-### 1. Simplification Rules  
+### 1. Simplification Rules
 _Core logic to reduce and clean expressions (e.g., `x + 0 → x`, `x * 1 → x`)._
 
-- [ ] Simplification Rules implemented and tested
+- [x] Simplification Rules implemented and tested
 
 ---
 
-### 2. Trigonometric Support  
+### 2. Trigonometric Support
 _Support for `sin`, `cos`, `tan` expressions, their derivatives, and evaluations._
 
-- [ ] Trigonometric Support implemented and tested
+- [x] Trigonometric Support implemented and tested
 
 ---
 


### PR DESCRIPTION
## Summary
- add recursive `simplified()` function for `MathExpr`
- provide unit tests for simplification
- mark Simplification Rules roadmap item as done
- call `simplified()` in operator overloads
- add arcsin, acos and atan support

## Testing
- `swift test -q`


------
https://chatgpt.com/codex/tasks/task_e_6864a74b69708331bd26abbc7f77a816