### PR TITLE
[Codex] Add piecewise support and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,19 @@ CalculoChart(
 
 > 📈 Animated drawing of the curve from left to right using `Charts` and `SwiftUI`.
 
+### 🎨 CalculoCanvas Example
+
+```swift
+CalculoCanvas(
+    expre: piecewise {
+        when(.x < 10, then: 4)
+        when(.x == 10, then: 5)
+        when(.x > 10, then: 10)
+    },
+    domain: 0...20
+)
+```
+
 ---
 
 ### 🧱 Goals

--- a/Sources/CalculoKit/Condition/Condition.swift
+++ b/Sources/CalculoKit/Condition/Condition.swift
@@ -19,8 +19,7 @@ public enum Condition: Sendable, Equatable {
             case .lessThanOrEqual(let v, let target) where v == variable:
                 return value <= target
             case .equalTo(let v, let target) where v == variable:
-                // TODO: Check if this is enough to compare or maybe we need to compare numerically
-                return value == target
+                return abs(value - target) < 1e-8
             case .greaterThan(let v, let target) where v == variable:
                 return value > target
             case .greaterThanOrEqual(let v, let target) where v == variable:

--- a/Sources/CalculoKit/LimitEvaluator/LimitEvaluator.swift
+++ b/Sources/CalculoKit/LimitEvaluator/LimitEvaluator.swift
@@ -121,8 +121,16 @@ public struct LimitEvaluator {
             return pow(b, e)
     
         case .piecewise(let branches):
-            // TODO: - Solve this 
-            return Evaluator().evaluate(expression, at: point, variable: variable)
+            guard let expr = branches.first(where: { item in
+                item.condition.isSatisfied(at: point, for: variable)
+            })?.expression else {
+                return nil
+            }
+            return evaluate(expr,
+                           approaching: point,
+                           variable: variable,
+                           tolerance: tolerance,
+                           maxIterations: maxIterations)
         }
     }
 }

--- a/Sources/CalculoKit/MathExpr/MathExpr.swift
+++ b/Sources/CalculoKit/MathExpr/MathExpr.swift
@@ -54,9 +54,17 @@ extension MathExpr: Equatable {
         case (.log(let a, let baseA), .log(let b, let baseB)):
             return baseA == baseB && a == b      // must match base and argument
 
+        case (.piecewise(let aItems), .piecewise(let bItems)):
+            guard aItems.count == bItems.count else { return false }
+            for (lhsItem, rhsItem) in zip(aItems, bItems) {
+                if lhsItem.condition != rhsItem.condition || lhsItem.expression != rhsItem.expression {
+                    return false
+                }
+            }
+            return true
+
         // Different cases ≠
         default:
-            // TODO: Add missing piecewise comparasion
             return false
         }
     }

--- a/Tests/CalculoKitTests/PiecewiseTests.swift
+++ b/Tests/CalculoKitTests/PiecewiseTests.swift
@@ -1,0 +1,38 @@
+import Testing
+@testable import CalculoKit
+
+struct PiecewiseTests {
+    @Test func testEvaluator() {
+        let expr = piecewise {
+            when(.x < 0, then: -1)
+            when(.x == 0, then: 0)
+            when(.x > 0, then: 1)
+        }
+        let eval = Evaluator()
+        #expect(eval.evaluate(expr, at: -2) == -1)
+        #expect(eval.evaluate(expr, at: 0) == 0)
+        #expect(eval.evaluate(expr, at: 2) == 1)
+    }
+
+    @Test func testDerivative() {
+        let expr = piecewise {
+            when(.x < 0, then: -1 * .x)
+            when(.x >= 0, then: .x)
+        }
+        let dx = expr.derivate()
+        let expected = piecewise {
+            when(.x < 0, then: -1)
+            when(.x >= 0, then: 1)
+        }
+        #expect(dx == expected)
+    }
+
+    @Test func testLimit() {
+        let expr = piecewise {
+            when(.x < 1, then: .x ** 2)
+            when(.x >= 1, then: .x)
+        }
+        let result = expr.limit(at: 1)
+        #expect(result == 1)
+    }
+}


### PR DESCRIPTION
## Summary
- handle equality comparisons for piecewise conditions
- implement piecewise comparison logic in `MathExpr`
- handle piecewise expressions in `LimitEvaluator`
- add demo usage of `CalculoCanvas` with piecewise in README
- create new unit tests covering piecewise evaluation, derivation and limits

## Testing
- `swift build`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6865421fb4dc833187ee976e1b58d2c2