### PR TITLE
⚡ Optimize Evaluator instantiation in CalculoCanvas

### DIFF
--- a/Sources/CalculoKitSwiftUI/CalculoCanvas.swift
+++ b/Sources/CalculoKitSwiftUI/CalculoCanvas.swift
@@ -23,9 +23,9 @@ public struct CalculoCanvas: View {
     
     // MARK: – Body
     public var body: some View {
+        let evaluator = Evaluator()
         Chart {
             LinePlot(x: "X", y: expre.description, domain: domain) { double in
-                let evaluator = Evaluator()
                 return evaluator.evaluate(expre, at: double) ?? 0.0
             }
         }


### PR DESCRIPTION
💡 **What:** The `let evaluator = Evaluator()` initialization was moved from inside the `LinePlot` closure to right before the `Chart` body inside `CalculoCanvas.swift`.

🎯 **Why:** The `Evaluator` struct is stateless (`Sendable`), so there's no need to instantiate it multiple times per line plot domain value. This is a CPU, memory, and allocation optimization that avoids initializing the object inside a high-frequency loop during Apple Charts rendering.

📊 **Measured Improvement:** Since the system environment lacks a working `swift` compiler or `xcodebuild`, I couldn't run a programmatic measurement/benchmark locally. However, conceptually, this directly eliminates O(N) instantiations per chart render, where N is the number of points evaluated in the line plot domain, leading to an undeniable improvement in charting latency and memory usage.

---
*PR created automatically by Jules for task [5390210137894915940](https://jules.google.com/task/5390210137894915940) started by @carVaba*