### PR TITLE
🧪 Improve test coverage for ln and log domain validation

### DIFF
--- a/Tests/CalculoKitTests/ConditionTests.swift
+++ b/Tests/CalculoKitTests/ConditionTests.swift
@@ -29,7 +29,6 @@ struct ConditionTests {
         // Create conditions for .x, but evaluate for .y
         // All should return false regardless of the value
 
-        let value = 5.0
         let target = 5.0
 
         #expect(Condition.lessThan(.x, target).isSatisfied(at: 2.0, for: .y) == false)

--- a/Tests/CalculoKitTests/LogAndPowDomainTests.swift
+++ b/Tests/CalculoKitTests/LogAndPowDomainTests.swift
@@ -13,8 +13,32 @@ struct LogAndPowDomainTests {
         #expect(abs(result! - 2.0) < 1e-6)
     }
 
-    @Test func testLogOfNegativeBase() {
+    @Test func testLogOfNegativeValue() {
         let expr = MathExpr.log(-10, base: 10)
+        let result = Evaluator().evaluate(expr, at: 0, variable: .x)
+        #expect(result == nil)
+    }
+
+    @Test func testLogOfZero() {
+        let expr = MathExpr.log(0, base: 10)
+        let result = Evaluator().evaluate(expr, at: 0, variable: .x)
+        #expect(result == nil)
+    }
+
+    @Test func testLnValid() {
+        let expr = MathExpr.ln(MathExpr.constant(exp(1)))
+        let result = Evaluator().evaluate(expr, at: 0, variable: .x)
+        #expect(abs(result! - 1.0) < 1e-6)
+    }
+
+    @Test func testLnOfNegativeValue() {
+        let expr = MathExpr.ln(-5)
+        let result = Evaluator().evaluate(expr, at: 0, variable: .x)
+        #expect(result == nil)
+    }
+
+    @Test func testLnOfZero() {
+        let expr = MathExpr.ln(0)
         let result = Evaluator().evaluate(expr, at: 0, variable: .x)
         #expect(result == nil)
     }

--- a/Tests/CalculoKitTests/LogAndPowDomainTests.swift
+++ b/Tests/CalculoKitTests/LogAndPowDomainTests.swift
@@ -3,6 +3,7 @@
 //  CalculoKit
 //
 import Testing
+import Foundation
 @testable import CalculoKit
 
 struct LogAndPowDomainTests {


### PR DESCRIPTION
🎯 **What:** Evaluator `.ln` and `.log` only allow arguments > 0. However, the tests only covered the base of `log` not being valid or the base being negative, missing the arguments of `log` and `ln`.
📊 **Coverage:** The test suite now includes cases ensuring that zero and negative inputs correctly evaluate to `nil` for `.ln` and `.log`. An existing incorrectly named test was also corrected.
✨ **Result:** Increased testing suite reliability and coverage for logarithmic evaluation.

---
*PR created automatically by Jules for task [5284707784205494825](https://jules.google.com/task/5284707784205494825) started by @carVaba*