### PR TITLE
🔒 Fix missing log base validation in LimitEvaluator

### DIFF
--- a/Sources/CalculoKit/LimitEvaluator/LimitEvaluator.swift
+++ b/Sources/CalculoKit/LimitEvaluator/LimitEvaluator.swift
@@ -103,7 +103,7 @@ public struct LimitEvaluator: Sendable {
             return log(v)
 
         case .log(let inner, let base):
-            guard let v = evaluate(inner, approaching: point, variable: variable), v > 0 else {
+            guard let v = evaluate(inner, approaching: point, variable: variable), v > 0, base > 0, base != 1 else {
                 return nil
             }
             return log(v) / log(base)

--- a/Tests/CalculoKitTests/LimitEvaluatorTests.swift
+++ b/Tests/CalculoKitTests/LimitEvaluatorTests.swift
@@ -24,4 +24,23 @@ struct LimitEvaluatorTests {
         let result = expr.limit(at: 0)
         #expect(abs((result ?? 0) - 1) < 0.01)
     }
+
+    @Test func testLimitOfLogWithInvalidBase() {
+        // Base is 1
+        let expr1 = MathExpr.log(.x, base: 1)
+        #expect(expr1.limit(at: 10) == nil)
+
+        // Base is <= 0
+        let expr2 = MathExpr.log(.x, base: 0)
+        #expect(expr2.limit(at: 10) == nil)
+
+        let expr3 = MathExpr.log(.x, base: -2)
+        #expect(expr3.limit(at: 10) == nil)
+
+        // Valid base
+        let expr4 = MathExpr.log(.x, base: 10)
+        let result4 = expr4.limit(at: 10)
+        #expect(result4 != nil)
+        #expect(abs((result4 ?? 0) - 1) < 0.01)
+    }
 }


### PR DESCRIPTION
🎯 **What:** The `LimitEvaluator` lacked validation for logarithm bases when evaluating limits, whereas `Evaluator` already had this checking (`base > 0` and `base != 1`). 

⚠️ **Risk:** Evaluating a log with base `1` would result in a divide-by-zero error, as `log(1) == 0`. Bases `<= 0` result in mathematically undefined logarithms. This could lead to crashes or unstable calculation results.

🛡️ **Solution:** Added a condition to ensure `base > 0, base != 1` in `LimitEvaluator.swift`'s `evaluate` method. Additionally, `LimitEvaluatorTests.swift` was expanded to rigorously test the handling of valid and invalid base limits.

---
*PR created automatically by Jules for task [5939281623378204877](https://jules.google.com/task/5939281623378204877) started by @carVaba*