### PR TITLE
⚡ Optimize LimitEvaluator by extracting Deriver instantiation

### DIFF
--- a/Sources/CalculoKit/LimitEvaluator/LimitEvaluator.swift
+++ b/Sources/CalculoKit/LimitEvaluator/LimitEvaluator.swift
@@ -39,6 +39,7 @@ public struct LimitEvaluator: Sendable {
         case .division(let lhs, let rhs):
             var numerator = lhs
             var denominator = rhs
+            let deriver = Deriver()
             for _ in 0..<maxIterations {
                 guard let l = evaluate(numerator, approaching: point, variable: variable,
                                        tolerance: tolerance, maxIterations: maxIterations),
@@ -55,8 +56,8 @@ public struct LimitEvaluator: Sendable {
                     return nil
                 }
                 
-                numerator = Deriver().evaluate(numerator, withRespectTo: variable)
-                denominator = Deriver().evaluate(denominator, withRespectTo: variable)
+                numerator = deriver.evaluate(numerator, withRespectTo: variable)
+                denominator = deriver.evaluate(denominator, withRespectTo: variable)
             }
             return nil
 


### PR DESCRIPTION
💡 **What:** The `Deriver` was being repeatedly instantiated inside a loop for numerator and denominator evaluation during a division operation in `Sources/CalculoKit/LimitEvaluator/LimitEvaluator.swift`. This fix extracts the `Deriver()` instantiation and performs it just once, outside the loop.
🎯 **Why:** This avoids redundant creation of the `Deriver` object, leading to a performance boost during evaluation. 
📊 **Measured Improvement:** I was unable to show a meaningful performance benchmark or run the full test suite in this sandbox environment because the `swift` executable (along with testing tools) is either missing from the available system PATH or encounters known environment crashes (signal 6/11) when invoked. The change is nonetheless a standard optimization to eliminate unnecessary recurring allocations and initialization overhead inside the inner loop.

---
*PR created automatically by Jules for task [2447943424518698950](https://jules.google.com/task/2447943424518698950) started by @carVaba*